### PR TITLE
docs: fix typo informations -> information

### DIFF
--- a/docs/release/v0.2.0-checklist.md
+++ b/docs/release/v0.2.0-checklist.md
@@ -17,7 +17,7 @@ ruff check tests/test_release_v020.py
 All checks passed
 
 pyright src/cain_agent/__init__.py tests/test_release_v020.py
-0 errors, 0 warnings, 0 informations
+0 errors, 0 warnings, 0 information
 ```
 
 At preparation time, the unmodified K8s RBAC suite still fails in a bare environment


### PR DESCRIPTION
One-word typo fix in `docs/release/v0.2.0-checklist.md:20`.
