### PR TITLE
fix(orchestrator): record failed stage in state.json when a handler raises

### DIFF
--- a/src/cain_agent/orchestrator.py
+++ b/src/cain_agent/orchestrator.py
@@ -165,11 +165,30 @@ class Orchestrator:
             artifacts_dir=self.workspace.stage_dir(stage),
         )
         started_at = _utc_now_iso()
-        result = self.handlers[stage](ctx)
+        history: list[dict[str, Any]] = list(state.get("history", []))
+        try:
+            result = self.handlers[stage](ctx)
+        except Exception as exc:
+            failed_at = _utc_now_iso()
+            history.append({
+                "stage": stage,
+                "started_at": started_at,
+                "finished_at": failed_at,
+                "status": "failed",
+                "error": f"{type(exc).__name__}: {exc}",
+            })
+            self._save_state({
+                "current_stage": stage,
+                "completed_stages": completed,
+                "updated_at": failed_at,
+                "history": history,
+                "failed_stage": stage,
+                "error": f"{type(exc).__name__}: {exc}",
+            })
+            raise
         finished_at = _utc_now_iso()
 
         completed.append(stage)
-        history: list[dict[str, Any]] = list(state.get("history", []))
         history.append({
             "stage": stage,
             "started_at": started_at,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -27,7 +27,7 @@ from cain_agent.orchestrator import (
     StageOrderError,
     StageResult,
 )
-from cain_agent.workspace import Workspace
+from cain_agent.workspace import STATE_FILE, Workspace
 
 
 @pytest.fixture
@@ -170,3 +170,47 @@ def test_artifacts_landed_in_stage_dirs(ws: Workspace) -> None:
     orch.run()
     for stage in STAGES:
         assert (ws.root / stage / f"{stage}-placeholder.json").exists()
+
+
+def _raising_handler(error: Exception) -> StageHandler:
+    def handler(ctx: StageContext) -> StageResult:
+        raise error
+
+    return handler
+
+
+def test_failed_stage_is_recorded_in_state(ws: Workspace) -> None:
+    orch = Orchestrator(
+        SDKExecutor(), ws, handlers={"recon": _raising_handler(RuntimeError("recon blew up"))}
+    )
+    with pytest.raises(RuntimeError, match="recon blew up"):
+        orch.run_stage("recon")
+    state = orch.load_state()
+    assert state["failed_stage"] == "recon"
+    assert "recon blew up" in state["error"]
+    assert state["completed_stages"] == []
+    assert state["current_stage"] == "recon"
+    assert state["history"][-1]["status"] == "failed"
+    assert ws.path(STATE_FILE).exists()
+
+
+def test_run_records_state_when_a_handler_raises(ws: Workspace) -> None:
+    orch = Orchestrator(
+        SDKExecutor(), ws, handlers={"recon": _raising_handler(RuntimeError("recon blew up"))}
+    )
+    with pytest.raises(RuntimeError):
+        orch.run()
+    assert orch.load_state()["failed_stage"] == "recon"
+
+
+def test_failure_marker_is_cleared_after_a_successful_stage(ws: Workspace) -> None:
+    orch = Orchestrator(
+        SDKExecutor(), ws, handlers={"recon": _raising_handler(RuntimeError("recon blew up"))}
+    )
+    with pytest.raises(RuntimeError, match="recon blew up"):
+        orch.run_stage("recon")
+    orch2 = Orchestrator(SDKExecutor(), ws)
+    orch2.run_stage("recon")
+    state = orch2.load_state()
+    assert state["completed_stages"] == ["recon"]
+    assert "failed_stage" not in state


### PR DESCRIPTION
## What

`Orchestrator.run_stage` now records a failed stage in `state.json` before re-raising, so a handler crash during `recon` / `test` / `report` no longer leaves the workspace with stage artifacts on disk but no record of what happened.

## Why

Fixes #10. As reported, when a stage handler raised, `run_stage` exited before `_save_state`, so:

- `completed_stages` stayed empty and `history` never saw the attempt;
- partial artifacts from the failed stage were orphaned with no trace;
- the caller (`cmd_run`) got an exception and then a `load_state()` that printed nothing useful.

## How

- `src/cain_agent/orchestrator.py` — wrap the handler call in `try / except Exception`; on failure persist `current_stage`, the unchanged `completed_stages`, `updated_at`, `history` (with a `{"status": "failed", "error": "..."}` entry) plus `failed_stage` and `error`, then re-`raise` the original exception unchanged.
- The success path is deliberately unchanged: same four state keys and the same history entry shape. A later successful `run_stage` rewrites the state dict, so `failed_stage` / `error` clear themselves — that is the recovery path covered by test 3.
- `run()` needed no change; it inherits the recording because `run_stage` re-raises.

## Tests

- `.venv/bin/python -m pytest tests/test_orchestrator.py -q` → 14 passed
- full suite `.venv/bin/python -m pytest -q` → 1118 passed, 3 skipped
- `ruff check` on both changed files → clean

Three new tests:

1. `test_failed_stage_is_recorded_in_state` — record present, `completed_stages` empty, history has the `failed` entry, `state.json` on disk.
2. `test_run_records_state_when_a_handler_raises` — the `run()` path persists the failure too.
3. `test_failure_marker_is_cleared_after_a_successful_stage` — a successful retry drops `failed_stage`.

## Mutation check

Reverted only the fix's behaviour (`except Exception` → `except ZeroDivisionError`) with the new tests left in place:

```
FAILED tests/test_orchestrator.py::test_failed_stage_is_recorded_in_state - KeyError: 'failed_stage'
FAILED tests/test_orchestrator.py::test_run_records_state_when_a_handler_raises - KeyError: 'failed_stage'
2 failed, 1 passed
```

Restored → 14 passed. The tests fail for the intended reason, so they guard the new behaviour instead of passing vacuously.

## AI disclosure

This change was implemented with AI assistance (OpenCode + muse-spark 1.3) and reviewed, tested, and mutation-checked by the submitter.

Fixes #10
